### PR TITLE
fix: fix multiple cookie error in debug

### DIFF
--- a/authcaptureproxy/auth_capture_proxy.py
+++ b/authcaptureproxy/auth_capture_proxy.py
@@ -358,15 +358,12 @@ class AuthCaptureProxy:
             if skip_auto_headers:
                 _LOGGER.debug("Discovered skip_auto_headers %s", skip_auto_headers)
                 headers.pop(SKIP_AUTO_HEADERS)
-            cookies = {}
-            for cookie, value in self.session.cookies.items():
-                cookies[cookie] = value
             _LOGGER.debug(
                 "Attempting %s to %s\nheaders: %s \ncookies: %s",
                 method,
                 site,
                 headers,
-                cookies,
+                self.session.cookies.jar,
             )
             try:
                 if mpwriter:


### PR DESCRIPTION
Print out the cookie jar instead of trying to parse the cookies into a
dict.
Closes #16