### PR TITLE
fix: add httpx timeout

### DIFF
--- a/authcaptureproxy/auth_capture_proxy.py
+++ b/authcaptureproxy/auth_capture_proxy.py
@@ -474,7 +474,7 @@ class AuthCaptureProxy:
                 _LOGGER.warning(
                     "Timeout during proxy request to %s: %s",
                     site,
-                    type(ex).__name__,
+                    ex.__class__.__name__,
                 )
                 return await self._build_response(
                     text=(


### PR DESCRIPTION
### Changes
- Configure an explicit httpx.Timeout for the proxy httpx.AsyncClient (increases read timeout to handle slower Amazon login flows).
- Catch httpx.TimeoutException in AuthCaptureProxy.all_handler() and return a user-facing error response instead of triggering a server-side 500.
### Why
Amazon’s login flow can involve slow redirect chains / bot checks / regional hops. httpx defaults are often too short for the read phase, resulting in httpx.ReadTimeout. Previously, this was not handled, breaking the login flow with a confusing 500.
### User impact
Instead of a hard 500, users will:
- more often succeed due to longer read timeout, and
- if a timeout still occurs, see a meaningful message indicating a network/latency issue and suggesting retry / connectivity checks.
### Related
Reported as AMP issue [#3308](https://github.com/alandtse/alexa_media_player/issues/3308) (symptom: 500 at` `auth/alexamedia/proxy/verify)`. Logs show `httpx.ReadTimeout` from `authcaptureproxy.auth_capture_proxy.AuthCaptureProxy.all_handler()`.

**Resolves:** Issue [#39](https://gitlab.com/keatontaylor/alexapy/-/issues/39)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timeout handling so network/request timeouts now produce clearer, user-facing timeout messages during login/proxy flows and halt further error processing.

* **Updates**
  * Configured explicit HTTP client timeouts (connect/read/write/pool) for more predictable request behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->