### PR TITLE
ci: switch to `ubuntu-latest` & revised matrixes

### DIFF
--- a/.github/workflows/pull-test.yml
+++ b/.github/workflows/pull-test.yml
@@ -98,7 +98,9 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true # optional (default = false)
 
-  # Legacy required checks for branch protection
+  # Legacy required check for branch protection.
+  # NOTE: This does NOT run Python 3.9 tests; it exists only because branch protection
+  # requires a status check named "build (3.9)". Remove once branch protection is updated.
   build_39:
     name: build (3.9)
     runs-on: ubuntu-latest


### PR DESCRIPTION
#### Updated GitHub Actions workflow
- runs-on: ubuntu-latest ✅ uses the most available runner pool
- max-parallel: 1 ✅ lets jobs start as soon as one runner is free (no “need 3 at once” bottleneck)
- python-version: "3.12" ✅ reduces runner demand to a single job (fast feedback) for general PRs.
- retains existing full matrix for main PRs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Restructured CI into a fast-feedback PR workflow and a full matrix workflow for main/master pushes; PR job now runs a single fast Python path while main runs a broader matrix. Expanded triggers to include pushes to main/master, improved checkout behavior, enhanced coverage reporting with token usage, and added legacy compatibility and markdown link checks.
* **Tests**
  * Expanded Python test matrix to cover 3.10–3.12.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->